### PR TITLE
Improve debug build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
+val app_name = "5.2.1"
+
 android {
     namespace = "de.simon.dankelmann.bluetoothlespam"
     compileSdk = 34
@@ -19,11 +21,16 @@ android {
 
     buildTypes {
         release {
+            resValue("string", "app_name", "${app_name}")>
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+        }
+        debug {
+            resValue("string", "app_name", "${app_name} Debug")>
+            applicationIdSuffix = ".debug"
         }
     }
     compileOptions {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
-val app_name = "5.2.1"
+val app_name = "Bluetooth LE Spam"
 
 android {
     namespace = "de.simon.dankelmann.bluetoothlespam"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
-    <string name="app_name">Bluetooth LE Spam</string>
+    <!-- Keep that commented out. It will lead to compile errors -->
+    <!--<string name="app_name">Bluetooth LE Spam</string>-->
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
     <string name="nav_header_title">Bluetooth LE Spam</string>


### PR DESCRIPTION
User can now install both of the APKs, release and debug. Debug build have now a `.debug` suffix, they also have a suffix in their app name like `Bluetooth LE Spam Debug`.

> These changes won't have any effects on the release build