### PR TITLE
fix(ui): proper iOS capitalization

### DIFF
--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/advertisement/AdvertisementFragment.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/advertisement/AdvertisementFragment.kt
@@ -182,8 +182,8 @@ class AdvertisementFragment : Fragment(), IAdvertisementServiceCallback, IAdvert
             AdvertisementSetType.ADVERTISEMENT_TYPE_CONTINUITY_NEW_AIRTAG -> "New Airtag Popup"
 
 
-            AdvertisementSetType.ADVERTISEMENT_TYPE_CONTINUITY_ACTION_MODALS -> "iOs Action Modal"
-            AdvertisementSetType.ADVERTISEMENT_TYPE_CONTINUITY_IOS_17_CRASH -> "iOs 17 Crash"
+            AdvertisementSetType.ADVERTISEMENT_TYPE_CONTINUITY_ACTION_MODALS -> "iOS Action Modal"
+            AdvertisementSetType.ADVERTISEMENT_TYPE_CONTINUITY_IOS_17_CRASH -> "iOS 17 Crash"
 
             AdvertisementSetType.ADVERTISEMENT_TYPE_EASY_SETUP_WATCH -> "Easy Setup Watch"
             AdvertisementSetType.ADVERTISEMENT_TYPE_EASY_SETUP_BUDS -> "Easy Setup Buds"


### PR DESCRIPTION
Small change, `iOs` was capitalized incorrectly and it has been fixed back to iOS.