### PR TITLE
Use local context

### DIFF
--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/MainActivity.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/MainActivity.kt
@@ -162,7 +162,7 @@ class MainActivity : AppCompatActivity() {
             val title = actionSettingsMenuItem?.title.toString()
             val spannable = SpannableString(title)
 
-            val textColor = resources.getColor(R.color.text_color, AppContext.getContext().theme)
+            val textColor = resources.getColor(R.color.text_color, theme)
             spannable.setSpan(
                 ForegroundColorSpan(textColor),
                 0,

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Models/BluetoothLeScanResult.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Models/BluetoothLeScanResult.kt
@@ -2,16 +2,10 @@ package de.simon.dankelmann.bluetoothlespam.Models
 
 import android.Manifest
 import android.bluetooth.le.ScanResult
+import android.content.Context
 import android.os.ParcelUuid
-import android.util.Log
 import androidx.core.util.forEach
-import androidx.core.util.plus
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext
-import de.simon.dankelmann.bluetoothlespam.Helpers.StringHelpers
-import de.simon.dankelmann.bluetoothlespam.Helpers.StringHelpers.Companion.toHexString
 import de.simon.dankelmann.bluetoothlespam.PermissionCheck.PermissionCheck
-import java.sql.Time
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 open class BluetoothLeScanResult {
@@ -37,8 +31,10 @@ open class BluetoothLeScanResult {
     }
 
     companion object {
+
         private const val _logTag = "BluetoothLeScanResult"
-        fun parseFromScanResult(scanResult: ScanResult):BluetoothLeScanResult{
+
+        fun parseFromScanResult(context: Context, scanResult: ScanResult): BluetoothLeScanResult {
             var model = BluetoothLeScanResult()
 
             // get raw message
@@ -66,10 +62,7 @@ open class BluetoothLeScanResult {
             model.address = scanResult.device.address
 
             // get device data
-            if (PermissionCheck.checkPermission(
-                    Manifest.permission.BLUETOOTH_CONNECT, AppContext.getContext()
-                )
-            ) {
+            if (PermissionCheck.checkPermission(Manifest.permission.BLUETOOTH_CONNECT, context)) {
                 if (scanResult.device != null && scanResult.device.name != null) {
                     model.deviceName = scanResult.device.name
                 }

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/PermissionCheck/PermissionCheck.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/PermissionCheck/PermissionCheck.kt
@@ -1,14 +1,11 @@
 package de.simon.dankelmann.bluetoothlespam.PermissionCheck
 
 import android.app.Activity
-import android.app.AlertDialog
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
-import android.util.Log
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext
 import de.simon.dankelmann.bluetoothlespam.Constants.Constants
 
 class PermissionCheck (){
@@ -69,81 +66,6 @@ class PermissionCheck (){
             }
 
             return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
-        }
-
-        fun requireAllPermissions(activity: Activity, permissions: Array<String>){
-            var requestNeeded: MutableList<String> = mutableListOf()
-            var dialogNeeded: MutableList<String> = mutableListOf()
-
-            permissions.forEachIndexed { index, permission ->
-                if(ContextCompat.checkSelfPermission(AppContext.getContext(), permission) == PackageManager.PERMISSION_GRANTED){
-                    //Log.d(_logTag, "Permission granted: $permission")
-                } else {
-                    if (ActivityCompat.shouldShowRequestPermissionRationale(activity, permission)) {
-                        // Show an explanation asynchronously
-                        Log.d(_logTag, "Show explanation for: $permission")
-                        dialogNeeded.add(permission)
-                    } else {
-                        requestNeeded.add(permission)
-                    }
-                }
-            }
-
-            // SHOW DIALOG
-            if(requestNeeded.size > 0){
-                requestPermissions(activity, requestNeeded.toTypedArray())
-                // showAlert(activity, requestNeeded.toTypedArray())
-            }
-
-            if(dialogNeeded.size > 0){
-                showArrayAlert(activity, dialogNeeded)
-                /*
-                dialogNeeded.forEachIndexed { index, permission ->
-                    run {
-                        showAlert(activity, permission)
-                    }
-                }*/
-            }
-        }
-
-        private fun showAlert(activity: Activity, permission:String) {
-            val builder = AlertDialog.Builder(activity)
-            builder.setTitle("Requesting permission")
-            builder.setMessage("App requires the following permission: $permission, please grant it in order to proceed")
-            builder.setPositiveButton("OK", { dialog, which -> requestPermissions(activity, arrayOf(permission)) })
-            builder.setNeutralButton("Cancel", null)
-            val dialog = builder.create()
-            dialog.show()
-        }
-
-        private fun showArrayAlert(activity: Activity, permissions:MutableList<String>) {
-            val builder = AlertDialog.Builder(activity)
-            builder.setTitle("Requesting permission")
-            builder.setMessage("App requires the following permission: ${permissions.toString()}, please grant it in order to proceed")
-            builder.setPositiveButton("OK") { dialog, which ->
-                requestPermissions(
-                    activity,
-                    permissions.toTypedArray()
-                )
-            }
-            builder.setNeutralButton("Cancel", null)
-            val dialog = builder.create()
-            dialog.show()
-        }
-
-        private fun requestPermissions(activity: Activity, permissions: Array<String>){
-            ActivityCompat.requestPermissions(activity, permissions, Constants.REQUEST_CODE_MULTIPLE_PERMISSIONS)
-        }
-
-        fun processPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray): Boolean {
-            var result = 0
-            if (grantResults.isNotEmpty()) {
-                for (item in grantResults) {
-                    result += item
-                }
-            }
-            if (result == PackageManager.PERMISSION_GRANTED) return true
-            return false
         }
     }
 }

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Services/BluetoothLeScanService.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Services/BluetoothLeScanService.kt
@@ -50,7 +50,7 @@ class BluetoothLeScanService(
 
 
     init {
-        _bluetoothAdapter = AppContext.getContext().bluetoothAdapter()
+        _bluetoothAdapter = context.bluetoothAdapter()
         if(_bluetoothAdapter != null){
             _bluetoothLeScanner = _bluetoothAdapter!!.bluetoothLeScanner
         }
@@ -196,7 +196,7 @@ class BluetoothLeScanService(
     override fun onScanResult(callbackType: Int, result: ScanResult?) {
         super.onScanResult(callbackType, result)
         if(result != null){
-            val bluetoothLeScanResult = BluetoothLeScanResult.parseFromScanResult(result)
+            val bluetoothLeScanResult = BluetoothLeScanResult.parseFromScanResult(context, result)
 
             // Check if its a Flipper
             if(BluetoothLeDeviceClassificationHelper.isFlipperDevice(bluetoothLeScanResult)){

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Services/LegacyAdvertisementService.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Services/LegacyAdvertisementService.kt
@@ -30,7 +30,7 @@ class LegacyAdvertisementService(
     private var _txPowerLevel:TxPowerLevel? = null
 
     init {
-        _bluetoothAdapter = AppContext.getContext().bluetoothAdapter()
+        _bluetoothAdapter = context.bluetoothAdapter()
         if(_bluetoothAdapter != null){
             _advertiser = _bluetoothAdapter!!.bluetoothLeAdvertiser
         }

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Services/ModernAdvertisementService.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Services/ModernAdvertisementService.kt
@@ -35,7 +35,7 @@ class ModernAdvertisementService(
     private var _txPowerLevel:TxPowerLevel? = null
 
     init {
-        _bluetoothAdapter = AppContext.getContext().bluetoothAdapter()
+        _bluetoothAdapter = context.bluetoothAdapter()
         if(_bluetoothAdapter != null){
             _advertiser = _bluetoothAdapter!!.bluetoothLeAdvertiser
         }

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/advertisementcollection/AdvertisementCollectionFragment.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/advertisementcollection/AdvertisementCollectionFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.cardview.widget.CardView
+import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.findNavController
@@ -20,9 +21,7 @@ import de.simon.dankelmann.bluetoothlespam.Models.AdvertisementSetCollection
 import de.simon.dankelmann.bluetoothlespam.Models.AdvertisementSetList
 import de.simon.dankelmann.bluetoothlespam.R
 import de.simon.dankelmann.bluetoothlespam.databinding.FragmentAdvertisementCollectionBinding
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
 
@@ -67,6 +66,7 @@ class AdvertisementCollectionFragment : Fragment() {
         // Get Layout View
         val advertisementSetCollectionView: View =
             layoutInflater.inflate(R.layout.listitem_advertisement_collection_start, null)
+        val context = advertisementSetCollectionView.context
 
         // Insert Data
         var titleTextView: TextView =
@@ -84,10 +84,7 @@ class AdvertisementCollectionFragment : Fragment() {
                 targetTextView.text = "Target: Android"
                 distanceTextView.text = "Distance: Close"
                 iconImageView.setImageDrawable(
-                    resources.getDrawable(
-                        R.drawable.ic_android,
-                        AppContext.getContext().theme
-                    )
+                    ResourcesCompat.getDrawable(resources, R.drawable.ic_android, context.theme)
                 )
             }
 
@@ -96,10 +93,7 @@ class AdvertisementCollectionFragment : Fragment() {
                 targetTextView.text = "Target: iOS"
                 distanceTextView.text = "Distance: Mixed"
                 iconImageView.setImageDrawable(
-                    resources.getDrawable(
-                        R.drawable.apple,
-                        AppContext.getContext().theme
-                    )
+                    ResourcesCompat.getDrawable(resources, R.drawable.apple, context.theme)
                 )
             }
 
@@ -108,10 +102,7 @@ class AdvertisementCollectionFragment : Fragment() {
                 targetTextView.text = "Target: Samsung"
                 distanceTextView.text = "Distance: Close"
                 iconImageView.setImageDrawable(
-                    resources.getDrawable(
-                        R.drawable.samsung,
-                        AppContext.getContext().theme
-                    )
+                    ResourcesCompat.getDrawable(resources, R.drawable.samsung, context.theme)
                 )
             }
 
@@ -120,10 +111,7 @@ class AdvertisementCollectionFragment : Fragment() {
                 targetTextView.text = "Target: Windows"
                 distanceTextView.text = "Distance: Close"
                 iconImageView.setImageDrawable(
-                    resources.getDrawable(
-                        R.drawable.microsoft,
-                        AppContext.getContext().theme
-                    )
+                    ResourcesCompat.getDrawable(resources, R.drawable.microsoft, context.theme)
                 )
             }
 
@@ -132,10 +120,7 @@ class AdvertisementCollectionFragment : Fragment() {
                 targetTextView.text = "Target: All"
                 distanceTextView.text = "Distance: Mixed"
                 iconImageView.setImageDrawable(
-                    resources.getDrawable(
-                        R.drawable.shuffle,
-                        AppContext.getContext().theme
-                    )
+                    ResourcesCompat.getDrawable(resources, R.drawable.shuffle, context.theme)
                 )
             }
 
@@ -144,10 +129,7 @@ class AdvertisementCollectionFragment : Fragment() {
                 targetTextView.text = "Target: undefined"
                 distanceTextView.text = "Distance: Undefined"
                 iconImageView.setImageDrawable(
-                    resources.getDrawable(
-                        R.drawable.ic_info,
-                        AppContext.getContext().theme
-                    )
+                    ResourcesCompat.getDrawable(resources, R.drawable.ic_info, context.theme)
                 )
             }
 
@@ -156,10 +138,7 @@ class AdvertisementCollectionFragment : Fragment() {
                 targetTextView.text = "Target: Lovespouse"
                 distanceTextView.text = "Distance: Far"
                 iconImageView.setImageDrawable(
-                    resources.getDrawable(
-                        R.drawable.heart,
-                        AppContext.getContext().theme
-                    )
+                    ResourcesCompat.getDrawable(resources, R.drawable.heart, context.theme)
                 )
             }
         }

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/preferences/PreferencesFragment.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/preferences/PreferencesFragment.kt
@@ -5,27 +5,20 @@ import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
-import android.util.Log
-import android.view.ContextMenu
-import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
-import androidx.lifecycle.Lifecycle
-import androidx.navigation.findNavController
-import androidx.navigation.ui.NavigationUI
 import androidx.preference.PreferenceFragmentCompat
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext
-import de.simon.dankelmann.bluetoothlespam.MainActivity
 import de.simon.dankelmann.bluetoothlespam.R
 
 
-class PreferencesFragment: PreferenceFragmentCompat(), MenuProvider {
+class PreferencesFragment : PreferenceFragmentCompat(), MenuProvider {
+
     private val _logTag = "PreferencesFragment"
+
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preferences, rootKey)
     }
@@ -47,21 +40,32 @@ class PreferencesFragment: PreferenceFragmentCompat(), MenuProvider {
 
     override fun onPrepareMenu(menu: Menu) {
         super.onPrepareMenu(menu)
-        val menuItems = listOf<MenuItem?>(menu?.findItem(R.id.nav_preferences), menu?.findItem(R.id.nav_set_tx_power))
+
+        val menuItems = listOf<MenuItem?>(
+            menu.findItem(R.id.nav_preferences),
+            menu.findItem(R.id.nav_set_tx_power)
+        )
+
+        val context = requireContext()
 
         menuItems.forEach { menuItem ->
             val actionSettingsMenuItem = menuItem
             val title = actionSettingsMenuItem?.title.toString()
             val spannable = SpannableString(title)
 
-            var textColor = resources.getColor(R.color.text_color, AppContext.getContext().theme)
+            var textColor = resources.getColor(R.color.text_color, context.theme)
 
-            if(menuItem?.itemId == R.id.nav_preferences) {
-                textColor = resources.getColor(R.color.text_color_light, AppContext.getContext().theme)
-                menuItem?.isEnabled = false
+            if (menuItem?.itemId == R.id.nav_preferences) {
+                textColor = resources.getColor(R.color.text_color_light, context.theme)
+                menuItem.isEnabled = false
             }
 
-            spannable.setSpan(ForegroundColorSpan(textColor), 0, spannable.length, Spannable.SPAN_INCLUSIVE_INCLUSIVE)
+            spannable.setSpan(
+                ForegroundColorSpan(textColor),
+                0,
+                spannable.length,
+                Spannable.SPAN_INCLUSIVE_INCLUSIVE
+            )
             actionSettingsMenuItem?.title = spannable
         }
     }

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/spamDetector/SpamDetectorFragment.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/spamDetector/SpamDetectorFragment.kt
@@ -67,7 +67,7 @@ class SpamDetectorFragment : IBluetoothLeScanCallback, Fragment() {
         _flipperDevicesRecyclerView = binding.spamDetectionFlipperDevicesList
         _spamPackageRecyclerView = binding.spamDetectionSpamPackageList
 
-        setupUi()
+        setupUi(root.context)
         setupFlipperDevicesListView()
         setupSpamPackagesListView(root.context)
 
@@ -81,30 +81,26 @@ class SpamDetectorFragment : IBluetoothLeScanCallback, Fragment() {
         _binding = null
     }
 
-    fun setupUi() {
+    fun setupUi(context: Context) {
         // Views
         val toggleButton = binding.spamDetectorToggleButton
         val detectionAnimation = binding.spamDetectionAnimation
 
         // Listeners
         toggleButton.setOnClickListener {
-            onToggleButtonClicked()
+            onToggleButtonClicked(context)
         }
 
         // Observers
         viewModel.isDetecting.observe(viewLifecycleOwner) { isDetecting ->
             if (isDetecting) {
                 toggleButton.setImageDrawable(
-                    ResourcesCompat.getDrawable(
-                        resources, R.drawable.pause, AppContext.getContext().theme
-                    )
+                    ResourcesCompat.getDrawable(resources, R.drawable.pause, context.theme)
                 )
                 detectionAnimation.playAnimation()
             } else {
                 toggleButton.setImageDrawable(
-                    ResourcesCompat.getDrawable(
-                        resources, R.drawable.play_arrow, AppContext.getContext().theme
-                    )
+                    ResourcesCompat.getDrawable(resources, R.drawable.play_arrow, context.theme)
                 )
                 detectionAnimation.cancelAnimation()
                 detectionAnimation.frame = 0
@@ -177,15 +173,15 @@ class SpamDetectorFragment : IBluetoothLeScanCallback, Fragment() {
         }
     }
 
-    fun onToggleButtonClicked() {
+    fun onToggleButtonClicked(context: Context) {
         if (viewModel.isDetecting.value == true) {
-            BluetoothLeScanForegroundService.stopService(AppContext.getContext())
+            BluetoothLeScanForegroundService.stopService(context)
             //AppContext.getBluetoothLeScanService().stopScanning()
             Log.d(_logTag, "Should Stop")
             viewModel.isDetecting.postValue(false)
         } else {
             BluetoothLeScanForegroundService.startService(
-                AppContext.getContext(),
+                context,
                 "Bluetooth LE Scan Foreground Service started..."
             )
             //AppContext.getBluetoothLeScanService().startScanning()

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/start/StartFragment.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/start/StartFragment.kt
@@ -14,6 +14,7 @@ import android.widget.TextView
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.cardview.widget.CardView
+import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext
@@ -49,7 +50,7 @@ class StartFragment : Fragment() {
         _binding = FragmentStartBinding.inflate(inflater, container, false)
         val root: View = binding.root
 
-        viewModel.appVersion.postValue(getAppVersion())
+        viewModel.appVersion.postValue(getAppVersion(root.context))
         viewModel.bluetoothSupport.postValue(getBluetoothSupportText())
 
         // register for bt enable callback
@@ -61,7 +62,7 @@ class StartFragment : Fragment() {
             }
         }
 
-        setupUi()
+        setupUi(root.context)
 
         checkRequiredPermissions(true)
         checkBluetoothAdapter(true)
@@ -76,9 +77,9 @@ class StartFragment : Fragment() {
         _binding = null
     }
 
-    fun getAppVersion():String?{
-        val manager = AppContext.getContext()!!.packageManager
-        val info = manager.getPackageInfo(AppContext.getContext().packageName, 0)
+    fun getAppVersion(context: Context): String? {
+        val manager = context.packageManager
+        val info = manager.getPackageInfo(context.packageName, 0)
         val version = info.versionName
         return version
     }
@@ -91,7 +92,7 @@ class StartFragment : Fragment() {
         }
     }
 
-    fun setupUi(){
+    fun setupUi(context: Context){
         // Seeding Animation
         val seedingAnimationView: View = binding.startFragmentDatabaseCardSeedingAnimation
         val databaseImageView: View = binding.startFragmentDatabaseCardIcon
@@ -160,13 +161,18 @@ class StartFragment : Fragment() {
             checkRequiredPermissions(true)
         }
 
+        val successBackground =
+            ResourcesCompat.getDrawable(resources, R.drawable.gradient_success, context.theme)
+        val errorBackground =
+            ResourcesCompat.getDrawable(resources, R.drawable.gradient_error, context.theme)
+
         // Permissions CardView Content
         val startFragmentPermissionCardViewContentWrapper: LinearLayout = binding.startFragmentPermissionCardViewContentWrapper
         viewModel.allPermissionsGranted.observe(viewLifecycleOwner) {
             if(it == true){
-                startFragmentPermissionCardViewContentWrapper.background = resources.getDrawable(R.drawable.gradient_success, AppContext.getContext().theme)
+                startFragmentPermissionCardViewContentWrapper.background = successBackground
             } else {
-                startFragmentPermissionCardViewContentWrapper.background = resources.getDrawable(R.drawable.gradient_error, AppContext.getContext().theme)
+                startFragmentPermissionCardViewContentWrapper.background = errorBackground
             }
         }
 
@@ -180,9 +186,9 @@ class StartFragment : Fragment() {
         val startFragmentBluetoothCardViewContentWrapper: LinearLayout = binding.startFragmentBluetoothCardViewContentWrapper
         viewModel.bluetoothAdapterIsReady.observe(viewLifecycleOwner) {
             if(it == true){
-                startFragmentBluetoothCardViewContentWrapper.background = resources.getDrawable(R.drawable.gradient_success, AppContext.getContext().theme)
+                startFragmentBluetoothCardViewContentWrapper.background = successBackground
             } else {
-                startFragmentBluetoothCardViewContentWrapper.background = resources.getDrawable(R.drawable.gradient_error, AppContext.getContext().theme)
+                startFragmentBluetoothCardViewContentWrapper.background = errorBackground
             }
         }
 
@@ -196,9 +202,9 @@ class StartFragment : Fragment() {
         val startFragmentServiceCardViewContentWrapper: LinearLayout = binding.startFragmentServiceCardViewContentWrapper
         viewModel.advertisementServiceIsReady.observe(viewLifecycleOwner) {
             if(it == true){
-                startFragmentServiceCardViewContentWrapper.background = resources.getDrawable(R.drawable.gradient_success, AppContext.getContext().theme)
+                startFragmentServiceCardViewContentWrapper.background = successBackground
             } else {
-                startFragmentServiceCardViewContentWrapper.background = resources.getDrawable(R.drawable.gradient_error, AppContext.getContext().theme)
+                startFragmentServiceCardViewContentWrapper.background = errorBackground
             }
         }
 
@@ -212,9 +218,9 @@ class StartFragment : Fragment() {
         val startFragmentDatabaseCardViewContentWrapper: LinearLayout = binding.startFragmentDatabaseCardViewContentWrapper
         viewModel.databaseIsReady.observe(viewLifecycleOwner) {
             if(it == true){
-                startFragmentDatabaseCardViewContentWrapper.background = resources.getDrawable(R.drawable.gradient_success, AppContext.getContext().theme)
+                startFragmentDatabaseCardViewContentWrapper.background = successBackground
             } else {
-                startFragmentDatabaseCardViewContentWrapper.background = resources.getDrawable(R.drawable.gradient_error, AppContext.getContext().theme)
+                startFragmentDatabaseCardViewContentWrapper.background = errorBackground
             }
         }
     }
@@ -272,7 +278,7 @@ class StartFragment : Fragment() {
         val activity = requireActivity()
         viewModel.bluetoothAdapterIsReady.postValue(false)
 
-        val bluetoothAdapter: BluetoothAdapter? = AppContext.getContext().bluetoothAdapter()
+        val bluetoothAdapter: BluetoothAdapter? = activity.bluetoothAdapter()
         if (bluetoothAdapter != null) {
             removeMissingRequirement("Bluetooth Adapter not found")
             if (bluetoothAdapter.isEnabled) {
@@ -382,7 +388,6 @@ class StartFragment : Fragment() {
             try {
                 val bluetoothLeScanService = BluetoothHelpers.getBluetoothLeScanService(context)
                 AppContext.setBluetoothLeScanService(bluetoothLeScanService)
-                //BluetoothLeScanForegroundService.startService(AppContext.getContext(), "Bluetooth LE Scan Foreground Service is running...")
             } catch (e:Exception){
                 addMissingRequirement("Bluetooth LE Scan Service not initialized")
                 advertisementServiceIsReady = false


### PR DESCRIPTION
Storing a Context in a static field is also a memory leak and should be avoided. This PR reduces the use of AppContext.context and replaces them with Contexts that are more local. Most of the time there is already an easy local context that we can use, sometimes we need to pass one in as a paramter.

Also remove some unused functions.