### PR TITLE
Refactor: Move bluetooth helpers from AppContext into BluetoothHelpers

### DIFF
--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/AppContext/AppContext.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/AppContext/AppContext.kt
@@ -15,20 +15,6 @@ abstract class AppContext {
         private lateinit var _bluetoothLeScanService: IBluetoothLeScanService
         private lateinit var _advertisementSetQueueHandler: AdvertisementSetQueueHandler
 
-        fun Context.bluetoothAdapter(): BluetoothAdapter? = (this.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager).adapter
-        fun Context.bluetoothManager(): BluetoothManager? = (this.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager)
-
-        fun isBluetooth5Supported():Boolean{
-            val bluetoothAdapter:BluetoothAdapter? = this.getContext().bluetoothAdapter()
-            if(bluetoothAdapter != null) {
-                return (bluetoothAdapter.isLe2MPhySupported
-                        && bluetoothAdapter.isLeCodedPhySupported
-                        && bluetoothAdapter.isLeExtendedAdvertisingSupported
-                        && bluetoothAdapter.isLePeriodicAdvertisingSupported)
-            }
-            return false
-        }
-
         fun setContext(context: Context) {
             _context = context
         }

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Helpers/BluetoothHelpers.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Helpers/BluetoothHelpers.kt
@@ -1,9 +1,10 @@
 package de.simon.dankelmann.bluetoothlespam.Helpers
 
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
 import android.content.Context
 import androidx.preference.PreferenceManager
 import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext.Companion.bluetoothAdapter
 import de.simon.dankelmann.bluetoothlespam.Interfaces.Services.IAdvertisementService
 import de.simon.dankelmann.bluetoothlespam.Interfaces.Services.IBluetoothLeScanService
 import de.simon.dankelmann.bluetoothlespam.R
@@ -12,19 +13,20 @@ import de.simon.dankelmann.bluetoothlespam.Services.LegacyAdvertisementService
 import de.simon.dankelmann.bluetoothlespam.Services.ModernAdvertisementService
 
 class BluetoothHelpers {
+
     companion object {
-        fun supportsBluetooth5(): Boolean {
-            var bluetoothAdapter = AppContext.getContext().bluetoothAdapter()
-            if (bluetoothAdapter != null) {
-                if (bluetoothAdapter!!.isLe2MPhySupported
-                    && bluetoothAdapter!!.isLeCodedPhySupported
-                    && bluetoothAdapter!!.isLeExtendedAdvertisingSupported
-                    && bluetoothAdapter!!.isLePeriodicAdvertisingSupported
-                ) {
-                    return true
-                }
-            }
-            return false
+
+        fun Context.bluetoothManager(): BluetoothManager? =
+            (this.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager)
+
+        fun Context.bluetoothAdapter(): BluetoothAdapter? = this.bluetoothManager()?.adapter
+
+        fun Context.isBluetooth5Supported(): Boolean {
+            val bluetoothAdapter = this.bluetoothAdapter() ?: return false
+            return (bluetoothAdapter.isLe2MPhySupported
+                    && bluetoothAdapter.isLeCodedPhySupported
+                    && bluetoothAdapter.isLeExtendedAdvertisingSupported
+                    && bluetoothAdapter.isLePeriodicAdvertisingSupported)
         }
 
         fun getAdvertisementService(context: Context): IAdvertisementService {

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Services/BluetoothLeAdvertisementService.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Services/BluetoothLeAdvertisementService.kt
@@ -2,31 +2,15 @@ package de.simon.dankelmann.bluetoothlespam.Services
 
 import android.Manifest
 import android.bluetooth.BluetoothAdapter
-import android.bluetooth.BluetoothDevice
-import android.bluetooth.BluetoothGattCharacteristic
-import android.bluetooth.BluetoothGattDescriptor
-import android.bluetooth.BluetoothGattServerCallback
-import android.bluetooth.BluetoothGattService
-import android.bluetooth.BluetoothManager
-import android.bluetooth.le.AdvertiseCallback
-import android.bluetooth.le.AdvertiseData
-import android.bluetooth.le.AdvertiseSettings
 import android.bluetooth.le.BluetoothLeAdvertiser
 import android.content.Context
-import android.content.pm.PackageManager
-import android.os.ParcelUuid
 import android.util.Log
-import androidx.core.app.ActivityCompat
 import androidx.preference.PreferenceManager
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext.Companion.bluetoothManager
-import de.simon.dankelmann.bluetoothlespam.Constants.Constants
 import de.simon.dankelmann.bluetoothlespam.Enums.TxPowerLevel
 import de.simon.dankelmann.bluetoothlespam.Interfaces.Callbacks.IBleAdvertisementServiceCallback
 import de.simon.dankelmann.bluetoothlespam.Models.AdvertisementSet
 import de.simon.dankelmann.bluetoothlespam.PermissionCheck.PermissionCheck
 import de.simon.dankelmann.bluetoothlespam.R
-import java.util.UUID
 
 
 class BluetoothLeAdvertisementService(

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Services/BluetoothLeScanService.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Services/BluetoothLeScanService.kt
@@ -10,17 +10,9 @@ import android.bluetooth.le.ScanSettings
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
-import android.os.ParcelUuid
 import android.util.Log
-import androidx.room.util.recursiveFetchArrayMap
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext.Companion.bluetoothAdapter
-import de.simon.dankelmann.bluetoothlespam.Enums.AdvertisementSetType
-import de.simon.dankelmann.bluetoothlespam.Enums.FlipperDeviceType
+import de.simon.dankelmann.bluetoothlespam.Helpers.BluetoothHelpers.Companion.bluetoothAdapter
 import de.simon.dankelmann.bluetoothlespam.Helpers.BluetoothLeDeviceClassificationHelper
-import de.simon.dankelmann.bluetoothlespam.Helpers.StringHelpers
-import de.simon.dankelmann.bluetoothlespam.Helpers.StringHelpers.Companion.toHexString
-import de.simon.dankelmann.bluetoothlespam.Interfaces.Callbacks.IAdvertisementServiceCallback
 import de.simon.dankelmann.bluetoothlespam.Interfaces.Callbacks.IBluetoothLeScanCallback
 import de.simon.dankelmann.bluetoothlespam.Interfaces.Services.IBluetoothLeScanService
 import de.simon.dankelmann.bluetoothlespam.Models.BluetoothLeScanResult
@@ -28,7 +20,6 @@ import de.simon.dankelmann.bluetoothlespam.Models.FlipperDeviceScanResult
 import de.simon.dankelmann.bluetoothlespam.Models.SpamPackageScanResult
 import de.simon.dankelmann.bluetoothlespam.PermissionCheck.PermissionCheck
 import java.time.Duration
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 class BluetoothLeScanService(
@@ -47,7 +38,6 @@ class BluetoothLeScanService(
     private val _millis_housekeeping_spam_packages:Long = 1000
     private val _millis_spam_package_lifetime = 5000
     private val _millis_flipper_device_lifetime = 5000
-
 
     init {
         _bluetoothAdapter = context.bluetoothAdapter()

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Services/LegacyAdvertisementService.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Services/LegacyAdvertisementService.kt
@@ -7,12 +7,10 @@ import android.bluetooth.le.AdvertiseSettings
 import android.bluetooth.le.BluetoothLeAdvertiser
 import android.content.Context
 import android.util.Log
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext.Companion.bluetoothAdapter
 import de.simon.dankelmann.bluetoothlespam.Enums.AdvertisementError
 import de.simon.dankelmann.bluetoothlespam.Enums.TxPowerLevel
+import de.simon.dankelmann.bluetoothlespam.Helpers.BluetoothHelpers.Companion.bluetoothAdapter
 import de.simon.dankelmann.bluetoothlespam.Interfaces.Callbacks.IAdvertisementServiceCallback
-import de.simon.dankelmann.bluetoothlespam.Interfaces.Callbacks.IBleAdvertisementServiceCallback
 import de.simon.dankelmann.bluetoothlespam.Interfaces.Services.IAdvertisementService
 import de.simon.dankelmann.bluetoothlespam.Models.AdvertisementSet
 import de.simon.dankelmann.bluetoothlespam.PermissionCheck.PermissionCheck

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Services/ModernAdvertisementService.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Services/ModernAdvertisementService.kt
@@ -2,21 +2,14 @@ package de.simon.dankelmann.bluetoothlespam.Services
 
 import android.Manifest
 import android.bluetooth.BluetoothAdapter
-import android.bluetooth.le.AdvertiseCallback
-import android.bluetooth.le.AdvertiseSettings
 import android.bluetooth.le.AdvertisingSet
 import android.bluetooth.le.AdvertisingSetCallback
 import android.bluetooth.le.BluetoothLeAdvertiser
 import android.content.Context
-import android.content.pm.PackageManager
-import android.os.Handler
-import android.os.Looper
 import android.util.Log
-import androidx.core.app.ActivityCompat
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext.Companion.bluetoothAdapter
 import de.simon.dankelmann.bluetoothlespam.Enums.AdvertisementError
 import de.simon.dankelmann.bluetoothlespam.Enums.TxPowerLevel
+import de.simon.dankelmann.bluetoothlespam.Helpers.BluetoothHelpers.Companion.bluetoothAdapter
 import de.simon.dankelmann.bluetoothlespam.Interfaces.Callbacks.IAdvertisementServiceCallback
 import de.simon.dankelmann.bluetoothlespam.Interfaces.Services.IAdvertisementService
 import de.simon.dankelmann.bluetoothlespam.Models.AdvertisementSet

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/start/StartFragment.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/start/StartFragment.kt
@@ -18,10 +18,11 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext.Companion.bluetoothAdapter
 import de.simon.dankelmann.bluetoothlespam.Database.AppDatabase
 import de.simon.dankelmann.bluetoothlespam.Handlers.AdvertisementSetQueueHandler
 import de.simon.dankelmann.bluetoothlespam.Helpers.BluetoothHelpers
+import de.simon.dankelmann.bluetoothlespam.Helpers.BluetoothHelpers.Companion.bluetoothAdapter
+import de.simon.dankelmann.bluetoothlespam.Helpers.BluetoothHelpers.Companion.isBluetooth5Supported
 import de.simon.dankelmann.bluetoothlespam.PermissionCheck.PermissionCheck
 import de.simon.dankelmann.bluetoothlespam.R
 import de.simon.dankelmann.bluetoothlespam.databinding.FragmentStartBinding
@@ -51,7 +52,7 @@ class StartFragment : Fragment() {
         val root: View = binding.root
 
         viewModel.appVersion.postValue(getAppVersion(root.context))
-        viewModel.bluetoothSupport.postValue(getBluetoothSupportText())
+        viewModel.bluetoothSupport.postValue(getBluetoothSupportText(root.context))
 
         // register for bt enable callback
         registerForResult = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -84,8 +85,8 @@ class StartFragment : Fragment() {
         return version
     }
 
-    fun getBluetoothSupportText():String{
-        if(AppContext.isBluetooth5Supported()){
+    fun getBluetoothSupportText(context: Context): String {
+        if (context.isBluetooth5Supported()) {
             return "Modern & Legacy"
         } else {
             return "Legacy only"


### PR DESCRIPTION
Move bluetooth helpers from AppContext into BluetoothHelpers.

This is also to reduce the usage of AppContext, and use the native Context instead. Before this change, `isBluetooth5Supported` was using the static context stored in the AppContext.

Also remove unused imports.