### PR TITLE
Fix text color on blue card in light mode

### DIFF
--- a/app/src/main/res/layout/listitem_advertisement_collection_start.xml
+++ b/app/src/main/res/layout/listitem_advertisement_collection_start.xml
@@ -27,7 +27,7 @@
                 android:layout_height="wrap_content"
                 android:paddingBottom="5dp"
                 android:text="Title"
-                android:textColor="@color/text_color_card_view_alternative"
+                android:textColor="@color/text_color_card_view_accent"
                 android:textSize="@dimen/textSizeHeadline"
                 android:textStyle="bold" />
 
@@ -48,14 +48,14 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:text="Target: -"
-                        android:textColor="@color/text_color_card_view_alternative_light" />
+                        android:textColor="@color/text_color_card_view_accent_light" />
 
                     <TextView
                         android:id="@+id/listItemAdvertisementSetCollectionStartDistance"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:text="Distance: Mixed"
-                        android:textColor="@color/text_color_card_view_alternative_light" />
+                        android:textColor="@color/text_color_card_view_accent_light" />
                 </LinearLayout>
 
                 <!-- Image Column -->
@@ -65,7 +65,7 @@
                     android:layout_height="match_parent"
                     android:layout_gravity="center"
                     android:src="@drawable/ic_android"
-                    app:tint="@color/text_color_card_view_alternative_light" />
+                    app:tint="@color/text_color_card_view_accent_light" />
             </LinearLayout>
         </LinearLayout>
     </androidx.cardview.widget.CardView>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -11,7 +11,7 @@
 
     <!-- CARDVIEW -->
     <color name="text_color_card_view_accent">#FFFFFF</color>
-    <color name="text_color_card_view_accent_light">#FFFFFF</color>
+    <color name="text_color_card_view_accent_light">#D1D1D1</color>
 
     <!-- CARDVIEW ALTERNATIVE -->
     <color name="text_color_card_view_alternative">@color/white</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -34,7 +34,7 @@
 
     <!-- CARDVIEW -->
     <color name="text_color_card_view_accent">#FFFFFF</color>
-    <color name="text_color_card_view_accent_light">#ababab</color>
+    <color name="text_color_card_view_accent_light">#D1D1D1</color>
 
     <!-- CARDVIEW ALTERNATIVE -->
     <color name="text_color_card_view_alternative">#000000</color>


### PR DESCRIPTION
This broke in https://github.com/simondankelmann/Bluetooth-LE-Spam/pull/346 where the card background was changed from green/yellow to blue. The text color was not updated and was still black, which has low contrast on blue.

Now that the Advertisement Collection cards are blue light the Info card, they should use the same color resources. Thus change them from “alternative card” to the main “card”.

Also tweak the “light” color version so that the sub-title colors are a bit nicer, and distinct from the title color.