### PR TITLE
Refactor: move ScanService from AppContext into Application

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,6 +45,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 
     <application
+        android:name=".BleSpamApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/AppContext/AppContext.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/AppContext/AppContext.kt
@@ -5,14 +5,12 @@ import android.bluetooth.BluetoothManager
 import android.content.Context
 import de.simon.dankelmann.bluetoothlespam.Handlers.AdvertisementSetQueueHandler
 import de.simon.dankelmann.bluetoothlespam.Interfaces.Services.IAdvertisementService
-import de.simon.dankelmann.bluetoothlespam.Interfaces.Services.IBluetoothLeScanService
 
 abstract class AppContext {
     companion object {
 
         private lateinit var _context: Context
         private lateinit var _advertisementService: IAdvertisementService
-        private lateinit var _bluetoothLeScanService: IBluetoothLeScanService
         private lateinit var _advertisementSetQueueHandler: AdvertisementSetQueueHandler
 
         fun setContext(context: Context) {
@@ -31,20 +29,8 @@ abstract class AppContext {
             return _advertisementService
         }
 
-        fun setBluetoothLeScanService(bluetoothLeScanService: IBluetoothLeScanService) {
-            _bluetoothLeScanService = bluetoothLeScanService
-        }
-
-        fun getBluetoothLeScanService(): IBluetoothLeScanService {
-            return _bluetoothLeScanService
-        }
-
         fun advertisementServiceIsInitialized(): Boolean {
             return this::_advertisementService.isInitialized
-        }
-
-        fun bluetoothLeScanServiceIsInitialized(): Boolean {
-            return this::_bluetoothLeScanService.isInitialized
         }
 
         fun setAdvertisementSetQueueHandler(advertisementSetQueueHandler: AdvertisementSetQueueHandler) {

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/BleSpamApplication.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/BleSpamApplication.kt
@@ -1,0 +1,17 @@
+package de.simon.dankelmann.bluetoothlespam
+
+import android.app.Application
+import de.simon.dankelmann.bluetoothlespam.Interfaces.Services.IBluetoothLeScanService
+import de.simon.dankelmann.bluetoothlespam.Services.BluetoothLeScanService
+
+class BleSpamApplication : Application() {
+
+    lateinit var scanService: IBluetoothLeScanService
+        private set
+
+    override fun onCreate() {
+        super.onCreate()
+
+        scanService = BluetoothLeScanService(this)
+    }
+}

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Helpers/BluetoothHelpers.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Helpers/BluetoothHelpers.kt
@@ -6,9 +6,7 @@ import android.content.Context
 import androidx.preference.PreferenceManager
 import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext
 import de.simon.dankelmann.bluetoothlespam.Interfaces.Services.IAdvertisementService
-import de.simon.dankelmann.bluetoothlespam.Interfaces.Services.IBluetoothLeScanService
 import de.simon.dankelmann.bluetoothlespam.R
-import de.simon.dankelmann.bluetoothlespam.Services.BluetoothLeScanService
 import de.simon.dankelmann.bluetoothlespam.Services.LegacyAdvertisementService
 import de.simon.dankelmann.bluetoothlespam.Services.ModernAdvertisementService
 
@@ -48,10 +46,6 @@ class BluetoothHelpers {
                     ModernAdvertisementService(context)
                 }
             }
-        }
-
-        fun getBluetoothLeScanService(context: Context): IBluetoothLeScanService {
-            return BluetoothLeScanService(context)
         }
     }
 }

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Interfaces/Services/IBluetoothLeScanService.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Interfaces/Services/IBluetoothLeScanService.kt
@@ -1,19 +1,17 @@
 package de.simon.dankelmann.bluetoothlespam.Interfaces.Services
 
-import de.simon.dankelmann.bluetoothlespam.Interfaces.Callbacks.IAdvertisementServiceCallback
 import de.simon.dankelmann.bluetoothlespam.Interfaces.Callbacks.IBluetoothLeScanCallback
 import de.simon.dankelmann.bluetoothlespam.Models.FlipperDeviceScanResult
 import de.simon.dankelmann.bluetoothlespam.Models.SpamPackageScanResult
 
 interface IBluetoothLeScanService {
     fun startScanning()
-
     fun stopScanning()
 
-    fun isScanning():Boolean
+    fun isScanning(): Boolean
 
-    fun getFlipperDevicesList():MutableList<FlipperDeviceScanResult>
-    fun getSpamPackageScanResultList():MutableList<SpamPackageScanResult>
+    fun getFlipperDevicesList(): MutableList<FlipperDeviceScanResult>
+    fun getSpamPackageScanResultList(): MutableList<SpamPackageScanResult>
 
     fun addBluetoothLeScanServiceCallback(callback: IBluetoothLeScanCallback)
     fun removeBluetoothLeScanServiceCallback(callback: IBluetoothLeScanCallback)

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/start/StartFragment.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/start/StartFragment.kt
@@ -384,17 +384,6 @@ class StartFragment : Fragment() {
             }
         }
 
-
-        if (!AppContext.bluetoothLeScanServiceIsInitialized()) {
-            try {
-                val bluetoothLeScanService = BluetoothHelpers.getBluetoothLeScanService(context)
-                AppContext.setBluetoothLeScanService(bluetoothLeScanService)
-            } catch (e:Exception){
-                addMissingRequirement("Bluetooth LE Scan Service not initialized")
-                advertisementServiceIsReady = false
-            }
-        }
-
         if(!AppContext.advertisementSetQueueHandlerIsInitialized()){
             try {
                 val service = AppContext.getAdvertisementService()


### PR DESCRIPTION
The Application is the proper place for central db, networking, logging, and other such global operations. Unlike the static AppContext, the Application has a proper lifecycle scope that is managed by the OS.

Also, the name “AppContext” already hints that maybe the Android-provided “applicationContext” is what we should be using :)

In this PR, only the scan service is migrated. The rest of AppContext I will cover in a future PR.