### PR TITLE
Refactor: Move AdvertisementService + QueueHandler into Application

### DIFF
--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Adapters/AdvertisementSetCollectionExpandableListViewAdapter.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Adapters/AdvertisementSetCollectionExpandableListViewAdapter.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.BaseExpandableListAdapter
 import android.widget.TextView
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext
 import de.simon.dankelmann.bluetoothlespam.Enums.AdvertisementState
 import de.simon.dankelmann.bluetoothlespam.Models.AdvertisementSet
 import de.simon.dankelmann.bluetoothlespam.Models.AdvertisementSetList

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/AppContext/AppContext.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/AppContext/AppContext.kt
@@ -1,17 +1,12 @@
 package de.simon.dankelmann.bluetoothlespam.AppContext
 
-import android.bluetooth.BluetoothAdapter
-import android.bluetooth.BluetoothManager
 import android.content.Context
-import de.simon.dankelmann.bluetoothlespam.Handlers.AdvertisementSetQueueHandler
-import de.simon.dankelmann.bluetoothlespam.Interfaces.Services.IAdvertisementService
 
 abstract class AppContext {
     companion object {
 
+        // TODO: Migrate away from needing this static field
         private lateinit var _context: Context
-        private lateinit var _advertisementService: IAdvertisementService
-        private lateinit var _advertisementSetQueueHandler: AdvertisementSetQueueHandler
 
         fun setContext(context: Context) {
             _context = context
@@ -20,34 +15,5 @@ abstract class AppContext {
         fun getContext(): Context {
             return _context
         }
-
-        fun setAdvertisementService(advertisementService: IAdvertisementService) {
-            _advertisementService = advertisementService
-        }
-
-        fun getAdvertisementService(): IAdvertisementService {
-            return _advertisementService
-        }
-
-        fun advertisementServiceIsInitialized(): Boolean {
-            return this::_advertisementService.isInitialized
-        }
-
-        fun setAdvertisementSetQueueHandler(advertisementSetQueueHandler: AdvertisementSetQueueHandler) {
-            _advertisementSetQueueHandler = advertisementSetQueueHandler
-        }
-
-        fun getAdvertisementSetQueueHandler(): AdvertisementSetQueueHandler {
-            return _advertisementSetQueueHandler
-        }
-
-        fun advertisementSetQueueHandlerIsInitialized(): Boolean {
-            return this::_advertisementSetQueueHandler.isInitialized
-        }
-
-        fun registerPermissionCallback(requestCode: Int, callback:Runnable){
-
-        }
-
     }
 }

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/BleSpamApplication.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/BleSpamApplication.kt
@@ -1,11 +1,21 @@
 package de.simon.dankelmann.bluetoothlespam
 
 import android.app.Application
+import de.simon.dankelmann.bluetoothlespam.Handlers.AdvertisementSetQueueHandler
+import de.simon.dankelmann.bluetoothlespam.Helpers.BluetoothHelpers
 import de.simon.dankelmann.bluetoothlespam.Helpers.ThemeManager
+import de.simon.dankelmann.bluetoothlespam.Interfaces.Services.IAdvertisementService
 import de.simon.dankelmann.bluetoothlespam.Interfaces.Services.IBluetoothLeScanService
 import de.simon.dankelmann.bluetoothlespam.Services.BluetoothLeScanService
 
+
 class BleSpamApplication : Application() {
+
+    lateinit var advertisementService: IAdvertisementService
+        private set
+
+    lateinit var queueHandler: AdvertisementSetQueueHandler
+        private set
 
     lateinit var scanService: IBluetoothLeScanService
         private set
@@ -17,6 +27,12 @@ class BleSpamApplication : Application() {
 
         super.onCreate()
 
+        setupAdvertisementService()
         scanService = BluetoothLeScanService(this)
+    }
+
+    fun setupAdvertisementService() {
+        advertisementService = BluetoothHelpers.getAdvertisementService(this)
+        queueHandler = AdvertisementSetQueueHandler(this, advertisementService)
     }
 }

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Handlers/AdvertisementSetQueueHandler.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Handlers/AdvertisementSetQueueHandler.kt
@@ -161,6 +161,14 @@ class AdvertisementSetQueueHandler(
         return false
     }
 
+    fun toggle(context: Context) {
+        if (_active) {
+            deactivate(context)
+        } else {
+            activate(context)
+        }
+    }
+
     fun activate(context: Context) {
         if (_active) {
             return

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Helpers/BluetoothHelpers.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Helpers/BluetoothHelpers.kt
@@ -4,7 +4,6 @@ import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
 import android.content.Context
 import androidx.preference.PreferenceManager
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext
 import de.simon.dankelmann.bluetoothlespam.Interfaces.Services.IAdvertisementService
 import de.simon.dankelmann.bluetoothlespam.R
 import de.simon.dankelmann.bluetoothlespam.Services.LegacyAdvertisementService

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/advertisementcollection/AdvertisementCollectionFragment.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/advertisementcollection/AdvertisementCollectionFragment.kt
@@ -1,5 +1,6 @@
 package de.simon.dankelmann.bluetoothlespam.ui.advertisementcollection
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -11,7 +12,7 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.findNavController
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext
+import de.simon.dankelmann.bluetoothlespam.BleSpamApplication
 import de.simon.dankelmann.bluetoothlespam.Enums.AdvertisementQueueMode
 import de.simon.dankelmann.bluetoothlespam.Enums.AdvertisementSetType
 import de.simon.dankelmann.bluetoothlespam.Enums.AdvertisementTarget
@@ -146,7 +147,7 @@ class AdvertisementCollectionFragment : Fragment() {
         // Hookup Events
         var cardView: CardView =
             advertisementSetCollectionView.findViewById(R.id.listItemAdvertisementSetCollectionStartCardview)
-        cardView.setOnClickListener {
+        cardView.setOnClickListener { view ->
             when (advertisementTarget) {
                 AdvertisementTarget.ADVERTISEMENT_TARGET_ANDROID -> {
                     onFastPairCardViewClicked()
@@ -165,7 +166,7 @@ class AdvertisementCollectionFragment : Fragment() {
                 }
 
                 AdvertisementTarget.ADVERTISEMENT_TARGET_KITCHEN_SINK -> {
-                    onKitchenSinkCardViewClicked()
+                    onKitchenSinkCardViewClicked(view.context)
                 }
 
                 AdvertisementTarget.ADVERTISEMENT_TARGET_LOVESPOUSE -> {
@@ -192,13 +193,14 @@ class AdvertisementCollectionFragment : Fragment() {
             val advertisementSetCollection =
                 buildAdvertisementCollection(advertisementSetTypes, advertisementSetCollectionTitle)
 
-            activity?.let {
-                it.runOnUiThread {
+            activity?.let { ac ->
+                ac.runOnUiThread {
                     // Pass Collection to Advertisement Fragment
-                    val navController = it.findNavController(R.id.nav_host_fragment)
-                    AppContext.getAdvertisementSetQueueHandler().deactivate(it)
-                    AppContext.getAdvertisementSetQueueHandler()
-                        .setAdvertisementSetCollection(advertisementSetCollection)
+                    val navController = ac.findNavController(R.id.nav_host_fragment)
+                    (ac.applicationContext as BleSpamApplication).queueHandler.apply {
+                        deactivate(ac)
+                        setAdvertisementSetCollection(advertisementSetCollection)
+                    }
                     navController.navigate(R.id.action_ad_coll_to_ad)
                 }
             }
@@ -289,9 +291,9 @@ class AdvertisementCollectionFragment : Fragment() {
         )
     }
 
-    fun onKitchenSinkCardViewClicked() {
+    fun onKitchenSinkCardViewClicked(context: Context) {
         // Set Random Mode for Kitchen Sink
-        AppContext.getAdvertisementSetQueueHandler()
+        (context.applicationContext as BleSpamApplication).queueHandler
             .setAdvertisementQueueMode(AdvertisementQueueMode.ADVERTISEMENT_QUEUE_MODE_RANDOM)
 
         navigateToAdvertisementFragmentWithType(

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/start/StartFragment.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/start/StartFragment.kt
@@ -18,10 +18,7 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import de.simon.dankelmann.bluetoothlespam.AppContext.AppContext
 import de.simon.dankelmann.bluetoothlespam.Database.AppDatabase
-import de.simon.dankelmann.bluetoothlespam.Handlers.AdvertisementSetQueueHandler
-import de.simon.dankelmann.bluetoothlespam.Helpers.BluetoothHelpers
 import de.simon.dankelmann.bluetoothlespam.Helpers.BluetoothHelpers.Companion.bluetoothAdapter
 import de.simon.dankelmann.bluetoothlespam.Helpers.BluetoothHelpers.Companion.isBluetooth5Supported
 import de.simon.dankelmann.bluetoothlespam.PermissionCheck.PermissionCheck
@@ -65,7 +62,6 @@ class StartFragment : Fragment() {
         setupUi(root.context)
 
         // These _should_ only need one-time initialisation, and thus don't need to be in onResume.
-        checkAdvertisementService(root.context)
         checkDatabase()
 
         return root
@@ -195,22 +191,6 @@ class StartFragment : Fragment() {
                 startFragmentBluetoothCardViewContentWrapper.background = successBackground
             } else {
                 startFragmentBluetoothCardViewContentWrapper.background = errorBackground
-            }
-        }
-
-        // Service CardView
-        val startFragmentServiceCardview: CardView = binding.startFragmentServiceCardview
-        startFragmentServiceCardview.setOnClickListener {
-            checkAdvertisementService(startFragmentServiceCardview.context)
-        }
-
-        // Service CardView Content
-        val startFragmentServiceCardViewContentWrapper: LinearLayout = binding.startFragmentServiceCardViewContentWrapper
-        viewModel.advertisementServiceIsReady.observe(viewLifecycleOwner) {
-            if(it == true){
-                startFragmentServiceCardViewContentWrapper.background = successBackground
-            } else {
-                startFragmentServiceCardViewContentWrapper.background = errorBackground
             }
         }
 
@@ -347,32 +327,5 @@ class StartFragment : Fragment() {
         allPermissions.forEach { permission ->
             PermissionCheck.checkPermissionAndRequest(permission, requireActivity())
         }
-    }
-
-    fun checkAdvertisementService(context: Context){
-        var advertisementServiceIsReady = true
-
-        if(!AppContext.advertisementServiceIsInitialized()){
-            try {
-                val advertisementService = BluetoothHelpers.getAdvertisementService(context)
-                AppContext.setAdvertisementService(advertisementService)
-            } catch (e:Exception){
-                addMissingRequirement("Advertisement Service not initialized")
-                advertisementServiceIsReady = false
-            }
-        }
-
-        if(!AppContext.advertisementSetQueueHandlerIsInitialized()){
-            try {
-                val service = AppContext.getAdvertisementService()
-                var advertisementSetQueueHandler = AdvertisementSetQueueHandler(context, service)
-                AppContext.setAdvertisementSetQueueHandler(advertisementSetQueueHandler)
-            } catch (e:Exception){
-                addMissingRequirement("Queue Handler not initialized")
-                advertisementServiceIsReady = false
-            }
-        }
-
-        viewModel.advertisementServiceIsReady.postValue(advertisementServiceIsReady)
     }
 }

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/start/StartViewModel.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/start/StartViewModel.kt
@@ -17,8 +17,6 @@ class StartViewModel : ViewModel() {
 
     val bluetoothAdapterIsReady = MutableLiveData<Boolean>(false)
 
-    val advertisementServiceIsReady = MutableLiveData<Boolean>(false)
-
     val databaseIsReady = MutableLiveData<Boolean>(false)
 
     val missingRequirements = MutableLiveData<MutableList<String>>(mutableListOf())

--- a/app/src/main/res/layout/fragment_start.xml
+++ b/app/src/main/res/layout/fragment_start.xml
@@ -131,48 +131,6 @@
             </androidx.cardview.widget.CardView>
             <!-- END: BLUETOOTH CARD -->
 
-            <!-- SERVICE CARD -->
-            <androidx.cardview.widget.CardView
-                android:id="@+id/start_fragment_service_cardview"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/cornerRadiusCardview"
-                app:cardCornerRadius="@dimen/cornerRadiusCardview"
-                app:cardElevation="0dp"
-                app:layout_constraintTop_toBottomOf="@id/start_fragment_bluetooth_cardview">
-
-                <LinearLayout
-                    android:id="@+id/startFragmentServiceCardViewContentWrapper"
-                    android:layout_width="match_parent"
-                    android:layout_height="50dp"
-                    android:background="@drawable/gradient_cardview_requirements"
-                    android:orientation="horizontal">
-
-                    <LinearLayout
-                        android:layout_width="50dp"
-                        android:layout_height="match_parent"
-                        android:gravity="center">
-
-                        <ImageView
-                            android:layout_width="35dp"
-                            android:layout_height="35dp"
-                            android:src="@drawable/bluetooth_audio_24"
-                            app:tint="@color/tint_icon_card_view_alternative" />
-                    </LinearLayout>
-
-                    <TextView
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:layout_weight="1"
-                        android:text="Advertisement Service"
-                        android:textColor="@color/text_color_card_view_alternative"
-                        android:textSize="@dimen/textSizeHeadline2" />
-                </LinearLayout>
-
-            </androidx.cardview.widget.CardView>
-            <!-- END: SERVICE CARD -->
-
             <!-- DATABASE CARD -->
             <androidx.cardview.widget.CardView
                 android:id="@+id/start_fragment_database_cardview"


### PR DESCRIPTION
This nearly completes the refactoring process (remove AppContext and use Android's native Application class instead).

This PR depends on #372. (There is some overlap where the same areas of code are changed.) Merge that first, then I will rebase this.