### PR TITLE
Update dependencies and target Android 17/16 (API 37/36.1)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,17 +1,14 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     alias(libs.plugins.agp.app)
-    alias(libs.plugins.kotlin)
     alias(libs.plugins.safeargs)
-    id("kotlin-kapt")
+    alias(libs.plugins.ksp)
 }
 
 val app_name = "Bluetooth LE Spam"
 
 android {
     namespace = "de.simon.dankelmann.bluetoothlespam"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "de.simon.dankelmann.bluetoothlespam"
@@ -54,14 +51,9 @@ android {
         targetCompatibility = JavaVersion.VERSION_21
     }
 
-    kotlin {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_21)
-        }
-    }
-
     buildFeatures {
         viewBinding = true
+        resValues = true
     }
 }
 
@@ -84,11 +76,8 @@ dependencies {
     implementation(libs.room.runtime)
     annotationProcessor(libs.room.compiler)
 
-    // To use Kotlin annotation processing tool (kapt)
-    kapt(libs.room.compiler)
-
     // To use Kotlin Symbol Processing (KSP)
-    //ksp(libs.room.compiler)
+    ksp(libs.room.compiler)
 
     // optional - Kotlin Extensions and Coroutines support for Room
     //implementation(libs.room.ktx)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.agp.app) apply false
-    alias(libs.plugins.kotlin) apply false
     alias(libs.plugins.safeargs) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,21 +1,21 @@
 [versions]
-agp = "8.12.0"
-kotlin = "2.2.10"
-core = "1.17.0"
+agp = "9.3.1"
+ksp = "2.3.11"
+core = "1.19.0"
 preference = "1.2.1"
-coroutines = "1.10.2"
+coroutines = "1.11.0"
 appcompat = "1.7.1"
-navigation = "2.9.3"
-lifecycle = "2.9.2"
+navigation = "2.9.8"
+lifecycle = "2.11.0"
 legacy = "1.0.0"
-constraintlayout = "2.2.1"
-material = "1.12.0"
-room = "2.7.2"
-lottie = "6.6.7"
+constraintlayout = "2.2.2"
+material = "1.14.0"
+room = "2.8.4"
+lottie = "6.7.1"
 
 [plugins]
 agp-app = { id = "com.android.application", version.ref = "agp" }
-kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 safeargs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "navigation" }
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=8fad3d78296ca518113f3d29016617c7f9367dc005f932bd9d93bf45ba46072b
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionSha256Sum=84fbba45c7f4c64abc77460e1c00f541e9f960e3c7ed2538f1ede19eacd873ae
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Bump AGP to 9.3.1 and Gradle wrapper to 9.7.0, required for
  compileSdk 37 (Android 17) support (AGP 8.x tops out at API 36.1).
- AGP 9 bundles Kotlin compilation itself, so the standalone
  org.jetbrains.kotlin.android plugin is removed; it also drops kapt
  support, so Room's annotation processor moves from kapt to KSP.
- Enable buildFeatures.resValues, now required by AGP 9 for the
  existing resValue() calls in buildTypes.
- Bump compileSdk/targetSdk to 37 and refresh androidx/Room/Material/
  coroutines/lottie versions to their current stable releases.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>