### PR TITLE
Fix crash on Advertisement collection open and foreground service permission mismatch

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
 
     <application
         android:name=".BleSpamApplication"
@@ -61,7 +61,7 @@
 
         <service android:foregroundServiceType="specialUse" android:name=".Services.AdvertisementForegroundService" />
 
-        <service android:foregroundServiceType="location" android:name=".Services.BluetoothLeScanForegroundService" />
+        <service android:foregroundServiceType="connectedDevice" android:name=".Services.BluetoothLeScanForegroundService" />
 
         <receiver android:name=".Services.AdvertisementForegroundService$ToggleButtonListener" />
 

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Database/Dao/AdvertiseDataDao.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/Database/Dao/AdvertiseDataDao.kt
@@ -10,7 +10,7 @@ import de.simon.dankelmann.bluetoothlespam.Database.Entities.AdvertiseSettingsEn
 @Dao
 interface AdvertiseDataDao {
     @Query("SELECT * FROM advertisedataentity WHERE id = :id")
-    fun findById(id: Int): AdvertiseDataEntity
+    fun findById(id: Int): AdvertiseDataEntity?
 
     @Query("SELECT * FROM advertisedataentity")
     fun getAll(): List<AdvertiseDataEntity>


### PR DESCRIPTION
Two independent bug fixes found while working on the BLE scan foreground service.

- `AdvertiseDataDao.findById()` was declared non-null but called through nullable-expecting call sites; the periodic-advertise sentinel ID `0` (never actually stored) triggered a Room `IllegalStateException` on lookup, crashing the app when opening an Advertisement collection.
- `BluetoothLeScanForegroundService` was declared with `foregroundServiceType="location"` and required `FOREGROUND_SERVICE_LOCATION`, but the service only performs BLE scanning and never touches a location API. Switched to `connectedDevice`, matching what the service actually does.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
