### PR TITLE
Add Jetpack Compose, Material3, and related dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.agp.app)
     alias(libs.plugins.safeargs)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.kotlin.compose)
 }
 
 val app_name = "Bluetooth LE Spam"
@@ -53,13 +54,21 @@ android {
 
     buildFeatures {
         viewBinding = true
+        compose = true
         resValues = true
+    }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
     }
 }
 
 
 dependencies {
     implementation(libs.airbnb.lottie)
+    implementation(libs.airbnb.lottie.compose)
 
     implementation(libs.core.ktx)
     implementation(libs.preference.ktx)
@@ -91,9 +100,36 @@ dependencies {
     // optional - Guava support for Room, including Optional and ListenableFuture
     //implementation(libs.room.guava)
 
-    // optional - Test helpers
-    //testImplementation(libs.room.testing)
-
     // optional - Paging 3 Integration
     //implementation(libs.room.paging)
+
+    // Compose
+    implementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.viewbinding)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.icons.extended)
+    implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.lifecycle.runtime.compose)
+
+    // Blur (floating nav bar backdrop only, see plan §4) + dynamic-color-consistent static palette
+    implementation(libs.haze)
+    implementation(libs.haze.materials)
+    implementation(libs.material.kolor)
+
+    // Test infra (T0)
+    testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.room.testing)
+    testImplementation(libs.androidx.compose.ui.test.junit4)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.test.espresso.core)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    androidTestImplementation(libs.room.testing)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.agp.app) apply false
     alias(libs.plugins.safeargs) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.kotlin.compose) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,25 +1,58 @@
 [versions]
 agp = "9.3.1"
 ksp = "2.3.11"
+kotlin = "2.3.0"
 core = "1.19.0"
 preference = "1.2.1"
 coroutines = "1.11.0"
 appcompat = "1.7.1"
 navigation = "2.9.8"
+navigationCompose = "2.9.8"
 lifecycle = "2.11.0"
 legacy = "1.0.0"
 constraintlayout = "2.2.2"
 material = "1.14.0"
 room = "2.8.4"
 lottie = "6.7.1"
+lottieCompose = "6.7.1"
+composeBom = "2025.11.00"
+activityCompose = "1.10.1"
+haze = "1.6.4"
+materialKolor = "5.0.0"
+robolectric = "4.15.1"
 
 [plugins]
 agp-app = { id = "com.android.application", version.ref = "agp" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 safeargs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "navigation" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 
 [libraries]
 airbnb-lottie = { group = "com.airbnb.android", name = "lottie", version.ref = "lottie" }
+airbnb-lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottieCompose" }
+
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-ui-viewbinding = { group = "androidx.compose.ui", name = "ui-viewbinding" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
+
+haze = { group = "dev.chrisbanes.haze", name = "haze", version.ref = "haze" }
+haze-materials = { group = "dev.chrisbanes.haze", name = "haze-materials", version.ref = "haze" }
+material-kolor = { group = "com.materialkolor", name = "material-kolor", version.ref = "materialKolor" }
+
+junit = { group = "junit", name = "junit", version = "4.13.2" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version = "1.2.1" }
+androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version = "3.6.1" }
 
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core" }
 preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "preference" }


### PR DESCRIPTION
Groundwork for the MD3 redesign: Compose BOM, Material3, navigation-compose,
material-icons-extended, haze (backdrop blur), material-kolor (static color
scheme generation), lottie-compose, plus JUnit/Robolectric/Room-testing/
Compose-UI-test for the test infra added alongside it. Pure dependency
addition — no source changes, still builds and passes existing tests
unchanged.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>