### PR TITLE
Add app color and theme mode pickers to Settings

### DIFF
--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/preferences/ThemeModePickerPreference.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/preferences/ThemeModePickerPreference.kt
@@ -1,0 +1,56 @@
+package de.simon.dankelmann.bluetoothlespam.ui.preferences
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.preference.Preference
+import androidx.preference.PreferenceViewHolder
+import de.simon.dankelmann.bluetoothlespam.Helpers.ThemeManager
+import de.simon.dankelmann.bluetoothlespam.R
+import de.simon.dankelmann.bluetoothlespam.ui.theme.SpecterTheme
+import de.simon.dankelmann.bluetoothlespam.ui.theme.ThemeModeOption
+import de.simon.dankelmann.bluetoothlespam.ui.theme.ThemeModePicker
+
+/** Embeds the Compose [ThemeModePicker] segmented control, same pattern as [ThemePickerPreference]. */
+class ThemeModePickerPreference(context: Context, attrs: AttributeSet?) : Preference(context, attrs) {
+
+    init {
+        layoutResource = R.layout.preference_theme_mode_picker
+        isSelectable = false
+    }
+
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
+        super.onBindViewHolder(holder)
+
+        val composeView = holder.findViewById(R.id.themeModePickerComposeView) as ComposeView
+        composeView.setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        composeView.setContent {
+            val currentMode = ThemeManager.getInstance().getTheme(context)
+            var selected by remember {
+                mutableStateOf(ThemeModeOption.entries.find { it.prefValue == currentMode } ?: ThemeModeOption.DEVICE)
+            }
+            val isOled = selected == ThemeModeOption.OLED
+            val seedColorArgb = ThemeManager.getInstance().getSeedColor(context)
+
+            SpecterTheme(
+                darkTheme = isOled || isSystemInDarkTheme(),
+                seedColorArgb = seedColorArgb,
+                amoled = isOled,
+            ) {
+                ThemeModePicker(
+                    selected = selected,
+                    onSelected = { option ->
+                        selected = option
+                        ThemeManager.getInstance().setTheme(context, option.prefValue)
+                    },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/preferences/ThemePickerPreference.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/preferences/ThemePickerPreference.kt
@@ -1,0 +1,52 @@
+package de.simon.dankelmann.bluetoothlespam.ui.preferences
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.preference.Preference
+import androidx.preference.PreferenceViewHolder
+import de.simon.dankelmann.bluetoothlespam.Helpers.ThemeManager
+import de.simon.dankelmann.bluetoothlespam.R
+import de.simon.dankelmann.bluetoothlespam.ui.theme.SpecterTheme
+import de.simon.dankelmann.bluetoothlespam.ui.theme.ThemeSwatchPicker
+
+/**
+ * Embeds the Compose [ThemeSwatchPicker] inside the classic AndroidX Preference screen — the
+ * swatch row (live two-tone previews, selection animation) doesn't map onto a plain list-item
+ * Preference, so this hosts it via ComposeView the same way MainActivity hosts Compose content
+ * inside the still-XML screen shell.
+ */
+class ThemePickerPreference(context: Context, attrs: AttributeSet?) : Preference(context, attrs) {
+
+    init {
+        layoutResource = R.layout.preference_theme_picker
+        isSelectable = false
+    }
+
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
+        super.onBindViewHolder(holder)
+
+        val composeView = holder.findViewById(R.id.themePickerComposeView) as ComposeView
+        composeView.setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        composeView.setContent {
+            var selectedSeedColor by remember {
+                mutableIntStateOf(ThemeManager.getInstance().getSeedColor(context))
+            }
+
+            SpecterTheme {
+                ThemeSwatchPicker(
+                    selectedSeedColor = selectedSeedColor,
+                    onSeedColorSelected = { argb ->
+                        selectedSeedColor = argb
+                        ThemeManager.getInstance().setSeedColor(context, argb)
+                    },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/theme/ThemeColorOptions.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/theme/ThemeColorOptions.kt
@@ -1,0 +1,24 @@
+package de.simon.dankelmann.bluetoothlespam.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+
+/**
+ * Preset seed colors for the theme picker (plan: theme picker, KernelSU-style). The brand blue
+ * leads the list since it's this app's own identity; the rest is a standard Material palette
+ * spread so there's a recognizable option in every hue.
+ */
+val themeSeedColorOptions: List<Int> = listOf(
+    BrandSeed,
+    Color(0xFFF44336), // red
+    Color(0xFFE91E63), // pink
+    Color(0xFF9C27B0), // purple
+    Color(0xFF3F51B5), // indigo
+    Color(0xFF2196F3), // blue
+    Color(0xFF00BCD4), // cyan
+    Color(0xFF009688), // teal
+    Color(0xFF4CAF50), // green
+    Color(0xFFFFC107), // amber
+    Color(0xFFFF9800), // orange
+    Color(0xFF795548), // brown
+).map { it.toArgb() }

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/theme/ThemeModePicker.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/theme/ThemeModePicker.kt
@@ -1,0 +1,89 @@
+package de.simon.dankelmann.bluetoothlespam.ui.theme
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Brightness1
+import androidx.compose.material.icons.filled.Brightness3
+import androidx.compose.material.icons.filled.Brightness7
+import androidx.compose.material.icons.filled.PhoneAndroid
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+enum class ThemeModeOption(val prefValue: String, val icon: ImageVector) {
+    DARK("dark", Icons.Filled.Brightness3),
+    DEVICE("default", Icons.Filled.PhoneAndroid),
+    LIGHT("light", Icons.Filled.Brightness7),
+    OLED("oled", Icons.Filled.Brightness1),
+}
+
+/**
+ * Connected segmented control for theme mode (Dark / Device / Light / OLED) — visual style
+ * requested to match a reference screenshot: one pill-shaped outer container, flat shared edges
+ * between segments, selected segment filled with a checkmark next to its icon.
+ */
+@Composable
+fun ThemeModePicker(
+    selected: ThemeModeOption,
+    onSelected: (ThemeModeOption) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val outerShape = RoundedCornerShape(28.dp)
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .clip(outerShape)
+            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, outerShape),
+    ) {
+        ThemeModeOption.entries.forEach { option ->
+            val isSelected = option == selected
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .background(
+                        if (isSelected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface,
+                    )
+                    .clickable { onSelected(option) },
+                contentAlignment = Alignment.Center,
+            ) {
+                if (isSelected) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Icon(
+                            imageVector = Icons.Rounded.Check,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                        Icon(
+                            imageVector = option.icon,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                    }
+                } else {
+                    Icon(
+                        imageVector = option.icon,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/theme/ThemeSwatchPicker.kt
+++ b/app/src/main/java/de/simon/dankelmann/bluetoothlespam/ui/theme/ThemeSwatchPicker.kt
@@ -1,0 +1,180 @@
+package de.simon.dankelmann.bluetoothlespam.ui.theme
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.Smartphone
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.materialkolor.dynamicColorScheme
+import de.simon.dankelmann.bluetoothlespam.Helpers.ThemeManager
+import de.simon.dankelmann.bluetoothlespam.R
+
+/**
+ * Theme picker (design borrowed from KernelSU's Color Palette screen — a horizontal row of
+ * circular swatches, each a live preview of what that seed color's MD3 scheme looks like, with
+ * a checkmark on the selected one). The first swatch is "Device" — the app's default — which
+ * keeps real Material You dynamic color; every other swatch pins a fixed seed color instead.
+ *
+ * [selectedSeedColor] is [ThemeManager.THEME_SEED_COLOR_DEVICE] (0) when following the device.
+ */
+@Composable
+fun ThemeSwatchPicker(
+    selectedSeedColor: Int,
+    onSeedColorSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val isDark = isSystemInDarkTheme()
+
+    LazyRow(
+        modifier = modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        item {
+            DeviceColorSwatch(
+                isSelected = selectedSeedColor == ThemeManager.THEME_SEED_COLOR_DEVICE,
+                onClick = { onSeedColorSelected(ThemeManager.THEME_SEED_COLOR_DEVICE) },
+            )
+        }
+
+        items(themeSeedColorOptions) { seedColorArgb ->
+            ColorSwatch(
+                seedColor = Color(seedColorArgb),
+                isDark = isDark,
+                isSelected = selectedSeedColor == seedColorArgb,
+                onClick = { onSeedColorSelected(seedColorArgb) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun DeviceColorSwatch(isSelected: Boolean, onClick: () -> Unit) {
+    // Reflects whatever the CURRENTLY active resolved scheme is (real device dynamic color on
+    // API 31+, the static brand fallback below that) — accurate rather than a guess.
+    val colorScheme = MaterialTheme.colorScheme
+    SwatchSurface(
+        primaryContainer = colorScheme.primaryContainer,
+        tertiaryContainer = colorScheme.tertiaryContainer,
+        selectedIndicatorColor = colorScheme.primary,
+        onIndicatorColor = colorScheme.onPrimary,
+        isSelected = isSelected,
+        onClick = onClick,
+        centerContent = {
+            if (!isSelected) {
+                Icon(
+                    imageVector = Icons.Rounded.Smartphone,
+                    contentDescription = stringResource(R.string.theme_color_device),
+                    tint = colorScheme.onPrimaryContainer,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun ColorSwatch(seedColor: Color, isDark: Boolean, isSelected: Boolean, onClick: () -> Unit) {
+    val colorScheme = dynamicColorScheme(seedColor = seedColor, isDark = isDark)
+    SwatchSurface(
+        primaryContainer = colorScheme.primaryContainer,
+        tertiaryContainer = colorScheme.tertiaryContainer,
+        selectedIndicatorColor = colorScheme.primary,
+        onIndicatorColor = colorScheme.onPrimary,
+        isSelected = isSelected,
+        onClick = onClick,
+        centerContent = {},
+    )
+}
+
+@Composable
+private fun SwatchSurface(
+    primaryContainer: Color,
+    tertiaryContainer: Color,
+    selectedIndicatorColor: Color,
+    onIndicatorColor: Color,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    centerContent: @Composable () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        shape = CircleShape,
+        modifier = Modifier.size(64.dp),
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Canvas(modifier = Modifier.size(64.dp)) {
+                drawArc(color = primaryContainer, startAngle = 180f, sweepAngle = 180f, useCenter = true)
+                drawArc(color = tertiaryContainer, startAngle = 0f, sweepAngle = 180f, useCenter = true)
+            }
+
+            val scale by animateFloatAsState(targetValue = if (isSelected) 1.1f else 1f, label = "swatch-scale")
+            Box(
+                modifier = Modifier.graphicsLayer { scaleX = scale; scaleY = scale },
+                contentAlignment = Alignment.Center,
+            ) {
+                AnimatedVisibility(
+                    visible = isSelected,
+                    enter = fadeIn() + scaleIn(initialScale = 0.8f),
+                    exit = fadeOut() + scaleOut(targetScale = 0.8f),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(28.dp)
+                            .border(2.dp, selectedIndicatorColor, CircleShape),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(20.dp)
+                                .clip(CircleShape)
+                                .background(selectedIndicatorColor, CircleShape),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.Check,
+                                contentDescription = null,
+                                tint = onIndicatorColor,
+                                modifier = Modifier.align(Alignment.Center).size(14.dp),
+                            )
+                        }
+                    }
+                }
+                AnimatedVisibility(
+                    visible = !isSelected,
+                    enter = fadeIn() + scaleIn(initialScale = 0.8f),
+                    exit = fadeOut() + scaleOut(targetScale = 0.8f),
+                ) {
+                    centerContent()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_settings_bluetooth.xml
+++ b/app/src/main/res/drawable/ic_settings_bluetooth.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorOnSurface"
+        android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z" />
+</vector>

--- a/app/src/main/res/drawable/ic_settings_duration.xml
+++ b/app/src/main/res/drawable/ic_settings_duration.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorOnSurface"
+        android:pathData="M11,17c0.55,0 1,-0.45 1,-1v-4c0,-0.55 -0.45,-1 -1,-1s-1,0.45 -1,1v4c0,0.55 0.45,1 1,1zM11,3c-4.97,0 -9,4.03 -9,9s4.03,9 9,9 9,-4.03 9,-9c0,-1.98 -0.64,-3.8 -1.73,-5.28l0.68,-0.68c0.39,-0.39 0.39,-1.02 0,-1.41l0,0c-0.39,-0.39 -1.03,-0.39 -1.42,0l-0.66,0.66C16.17,3.61 13.72,3 11,3zM11,19c-3.87,0 -7,-3.13 -7,-7s3.13,-7 7,-7 7,3.13 7,7 -3.13,7 -7,7zM17,1h-4c-0.55,0 -1,0.45 -1,1s0.45,1 1,1h4c0.55,0 1,-0.45 1,-1s-0.45,-1 -1,-1z" />
+</vector>

--- a/app/src/main/res/drawable/ic_settings_logging.xml
+++ b/app/src/main/res/drawable/ic_settings_logging.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorOnSurface"
+        android:pathData="M14,2H6C4.9,2 4.01,2.9 4.01,4L4,20c0,1.1 0.89,2 1.99,2H18c1.1,0 2,-0.9 2,-2V8L14,2zM6,20V4h7v5h5v11H6zM8,14v2h8v-2H8zM8,10v2h8v-2H8z" />
+</vector>

--- a/app/src/main/res/drawable/ic_tx_power.xml
+++ b/app/src/main/res/drawable/ic_tx_power.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorOnSurface"
+        android:pathData="M11,21h-1l1,-7H7.5c-0.58,0 -0.57,-0.32 -0.38,-0.66c0.19,-0.34 0.05,-0.08 0.07,-0.11C8.48,10.94 10.42,7.54 13,3h1l-1,7h3.5c0.49,0 0.56,0.33 0.47,0.51l-0.07,0.15C12.96,17.55 11,21 11,21z" />
+</vector>

--- a/app/src/main/res/layout/preference_theme_mode_picker.xml
+++ b/app/src/main/res/layout/preference_theme_mode_picker.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingTop="12dp"
+    android:paddingBottom="12dp"
+    android:paddingHorizontal="16dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:text="@string/preference_theme_mode"
+        android:textAppearance="?attr/textAppearanceTitleMedium" />
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/themeModePickerComposeView"
+        android:layout_width="match_parent"
+        android:layout_height="56dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/preference_theme_picker.xml
+++ b/app/src/main/res/layout/preference_theme_picker.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingTop="12dp"
+    android:paddingBottom="4dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginBottom="8dp"
+        android:text="@string/theme_color_title"
+        android:textAppearance="?attr/textAppearanceTitleMedium" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginBottom="12dp"
+        android:text="@string/theme_color_summary"
+        android:textAppearance="?attr/textAppearanceBodyMedium" />
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/themePickerComposeView"
+        android:layout_width="match_parent"
+        android:layout_height="80dp" />
+
+</LinearLayout>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -11,16 +11,4 @@
         <item>balanced</item>
         <item>low_latency</item>
     </string-array>
-    
-    <string-array name="theme_mode_entries">
-        <item>@string/preference_theme_mode_follow_system</item>
-        <item>@string/preference_theme_mode_light</item>
-        <item>@string/preference_theme_mode_dark</item>
-    </string-array>
-
-    <string-array name="theme_mode_values">
-        <item>default</item>
-        <item>light</item>
-        <item>dark</item>
-    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,11 @@
     <string name="action_settings">Settings</string>
     <string name="action_set_tx_power">TX Power</string>
 
+    <string name="theme_category_title">Theme</string>
+    <string name="theme_color_title">App Color</string>
+    <string name="theme_color_summary">Use your device\'s color, or pick one</string>
+    <string name="theme_color_device">Device</string>
+
     <string name="menu_preferences">Settings</string>
     <string name="menu_start">Start</string>
     <string name="menu_spam_detector">Spam Detector</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -7,6 +7,7 @@
             app:title="@string/preference_title_use_legacy_advertising"
             app:summary="@string/preference_summary_use_legacy_advertising"
             app:defaultValue="true"
+            app:icon="@drawable/ic_settings_bluetooth"
             />
 
         <EditTextPreference
@@ -17,7 +18,21 @@
             android:selectAllOnFocus="true"
             android:singleLine="true"
             android:summary="Duration of an Advertisement in Milliseconds. Recommended: 1000 - 10000"
-            android:title="Advertisement Duration (ms)" />
+            android:title="Advertisement Duration (ms)"
+            android:icon="@drawable/ic_settings_duration" />
+
+        <Preference
+            app:key="tx_power"
+            app:title="@string/action_set_tx_power"
+            app:icon="@drawable/ic_tx_power" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/theme_category_title">
+        <de.simon.dankelmann.bluetoothlespam.ui.preferences.ThemePickerPreference
+            app:key="theme_seed_color_picker" />
+
+        <de.simon.dankelmann.bluetoothlespam.ui.preferences.ThemeModePickerPreference
+            app:key="theme_mode_picker" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="Debug Settings">
@@ -25,14 +40,8 @@
             app:key="@string/preference_key_enable_logging"
             app:title="@string/preference_title_enable_logging"
             app:summary="@string/preference_summary_enable_logging"
-            app:defaultValue="false" />
-
-        <ListPreference
-            app:key="theme_mode"
-            app:title="@string/preference_theme_mode"
-            app:entries="@array/theme_mode_entries"
-            app:entryValues="@array/theme_mode_values"
-            app:defaultValue="default" />
+            app:defaultValue="false"
+            app:icon="@drawable/ic_settings_logging" />
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
User-facing controls for the theming system added in the previous PR.

- `ThemeSwatchPicker`: device color plus 11 preset seed colors, with a live two-tone preview.
- `ThemeModePicker`: a 4-segment Dark / Device / Light / OLED control, filled edge to edge and colored from whichever seed is currently active.
- Both hosted in the classic Preferences screen via `ComposeView` — the same interop pattern `MainActivity` uses for the nav bar.
- Settings screen restructure: themed icons on each row, TX power moved to its own Preference row, old `theme_mode` ListPreference removed.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
